### PR TITLE
Adds an install rule for the mapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,22 @@
-BIN=bin/mapper
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S), Linux)
+TARGET = so
+prefix?=/usr
+endif
+ifeq ($(UNAME_S), Darwin)
+TARGET = dylib
+prefix?=/usr/local
+endif
+
+BIN=bin/cgra-mapper
 
 TEST_FILES=$(wildcard examples/[^_]*.json)
 MAPPED_FILES=$(patsubst examples/%, mapped/%, $(TEST_FILES))
 
 all: $(BIN)
 
-#This Will copy mapper into bin/
-.PHONY: bin/mapper
+#This Will copy cgra-mapper into bin/
+.PHONY: bin/cgra-mapper
 $(BIN): 
 	$(MAKE) -C src
 
@@ -33,4 +43,7 @@ clean:
 	-rm -f bin/*
 	-rm -f mapped/*
 	-rm -f _*.json
+
+install: $(BIN)
+	install $< $(prefix)/bin
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,7 @@ all: build/mapper
 build/mapper: build/mapper.o 
 	$(CXX) $(LDFLAGS) -o $@ $< $(LIBS)
 	cp build/mapper ../bin/.
+	cp build/mapper ../bin/cgra-mapper
 
 build/%.o: %.cpp 
 	$(CXX) $(CXXFLAGS) -c $^ -o $@


### PR DESCRIPTION
Prefixes it with cgra- to reduce the chance of conflict in users path.

Maintains the unprefixed version copied to `bin` to maintain backwards
compatability with existing code.