### PR TITLE
Add basic mantle test for mapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ before_install:
   - pip install coreir
   - make -j
 
+  # Dependences for mantle tests
+  - pip install delegator.py
+  - pip install git+git://github.com/phanrahan/magma.git
+  - pip install git+git://github.com/phanrahan/mantle.git
+
+
 script:
   - make test
   - make pytest

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,13 @@
+# content of conftest.py
+import sys
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mantle_test():
+    """
+    Clear the circuit cache before running, allows name reuse across tests
+    without collisions
+    """
+    import magma.config
+    magma.config.set_compile_dir('callee_file_dir')

--- a/tests/test_mantle/build/.gitignore
+++ b/tests/test_mantle/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test_mantle/gold/test_add16.json
+++ b/tests/test_mantle/gold/test_add16.json
@@ -1,0 +1,26 @@
+{"top":"global.Add16",
+"namespaces":{
+  "global":{
+    "modules":{
+      "Add16":{
+        "type":["Record",[
+          ["I0",["Array",16,"BitIn"]],
+          ["I1",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "inst0":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["inst0.in0","self.I0"],
+          ["inst0.in1","self.I1"],
+          ["inst0.out","self.O"]
+        ]
+      }
+    }
+  }
+}
+}

--- a/tests/test_mantle/gold/test_add16_mapped.json
+++ b/tests/test_mantle/gold/test_add16_mapped.json
@@ -1,0 +1,48 @@
+{"top":"global.Add16",
+"namespaces":{
+  "commonlib":{
+    
+  },
+  "global":{
+    "modules":{
+      "Add16":{
+        "type":["Record",[
+          ["I0",["Array",16,"BitIn"]],
+          ["I1",["Array",16,"BitIn"]],
+          ["O",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "inst0_PE":{
+            "genref":"cgralib.PE",
+            "genargs":{"numbitports":["Int",3], "numdataports":["Int",2], "op_kind":["String","alu"], "width":["Int",16]},
+            "modargs":{"alu_op":["String","add"], "data0_mode":["String","BYPASS"], "data0_value":[["BitVector",16],"16'h0000"], "data1_mode":["String","BYPASS"], "data1_value":[["BitVector",16],"16'h0000"]}
+          },
+          "io16_O":{
+            "genref":"cgralib.IO",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"mode":["String","o"]}
+          },
+          "io16in_I0":{
+            "genref":"cgralib.IO",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"mode":["String","i"]}
+          },
+          "io16in_I1":{
+            "genref":"cgralib.IO",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"mode":["String","i"]}
+          }
+        },
+        "connections":[
+          ["io16_O.in","inst0_PE.data.out"],
+          ["io16in_I0.out","inst0_PE.data.in.0"],
+          ["io16in_I1.out","inst0_PE.data.in.1"]
+        ]
+      }
+    }
+  },
+  "mantle":{
+    
+  }
+}
+}

--- a/tests/test_mantle/test_arith.py
+++ b/tests/test_mantle/test_arith.py
@@ -1,0 +1,19 @@
+import delegator
+import os
+os.environ["MANTLE"] = "coreir"
+import magma as m
+from magma.testing import check_files_equal
+from mantle.coreir.arith import DefineAdd, DefineSub, DefineNegate, DefineASR
+from magma.testing.newfunction import testvectors as function_test
+from magma.simulator.python_simulator import testvectors as simulator_test
+
+
+def test_add():
+    width = 16
+    m.compile("build/test_add16", DefineAdd(width), output="coreir")
+    assert check_files_equal(__file__,
+            "build/test_add16.json", "gold/test_add16.json")
+
+    delegator.run("../../bin/cgra-mapper build/test_add16.json build/test_add16_mapped.json")
+    assert check_files_equal(__file__,
+            "build/test_add16_mapped.json", "gold/test_add16_mapped.json")


### PR DESCRIPTION
Generates an `add16` through mantle, checks that it can be mapped and runs a regression check on the mapped output .json.

This should be the basis for PnR tests (basically, unit test that we can map the primitives, then try random composition of primitives).