### PR TITLE
switch to cmake build system

### DIFF
--- a/.cmake/FindCoreIR.cmake
+++ b/.cmake/FindCoreIR.cmake
@@ -1,0 +1,68 @@
+# - Try to Find CoreIR
+# Once done, this will define
+#
+#  COREIR_FOUND - system has CoreIR dir.
+#  COREIR_INCLUDE_DIR - directories which contain the CoreIR headers.
+#  COREIR_LIBRARIES - libraries required to link against CoreIR.
+#  Copyleft @ Keyi Zhang
+#  If current CoreIR use any auto build system, things will be much easier
+
+if(DEFINED COREIR_DIR AND IS_DIRECTORY "${COREIR_DIR}")
+    set(COREIR_FOUND TRUE)
+elseif(DEFINED ENV{COREIR_DIR} AND IS_DIRECTORY "$ENV{COREIR_DIR}")
+    set(COREIR_FOUND TRUE)
+    set(COREIR_DIR $ENV{COREIR_DIR})
+    message(STATUS "Using COREIR_DIR ${COREIR_DIR} from environment variable")
+else()
+    message(WARNING "COREIR_DIR not specified. Use env variable $COREIR_DIR "
+                    "or specify it on the command line with -D COREIR_DIR=...")
+endif()
+
+# convert to absolute
+if (NOT IS_ABSOLUTE ${COREIR_DIR})
+    MESSAGE(FATAL_ERROR "${COREIR_DIR} has to be absolute")
+endif()
+
+find_path(COREIR_INCLUDE_DIR NAMES coreir.h
+    PATHS "${COREIR_DIR}/include"
+)
+
+# that's lots of libraries. more than most common FOSS!
+find_library(COREIR_LIB NAMES coreir
+    PATHS "${COREIR_DIR}/lib"
+)
+
+find_library(COREIR_AETHERLING coreir-aetherlinglib
+    PATHS "${COREIR_DIR}/lib"
+)
+
+find_library(COREIR_COMMON coreir-commonlib
+    PATHS "${COREIR_DIR}/lib"
+)
+
+find_library(COREIR_LIB_C coreir-c
+    PATHS "${COREIR_DIR}/lib"
+)
+
+find_library(COREIR_ICE coreir-ice40
+    PATHS "${COREIR_DIR}/lib"
+)
+
+find_library(COREIR_RTL coreir-rtlil
+    PATHS "${COREIR_DIR}/lib"
+)
+
+set(COREIR_LIBRARIES ${COREIR_LIB} ${COREIR_AETHERLING} ${COREIR_COMMON}
+    ${COREIR_LIB_C} ${COREIR_ICE} ${COREIR_RTL})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CoreIR DEFAULT_MSG COREIR_FOUND
+                                  COREIR_INCLUDE_DIR
+                                  COREIR_LIB
+                                  COREIR_AETHERLING
+                                  COREIR_COMMON
+                                  COREIR_LIB_C
+                                  COREIR_ICE
+                                  COREIR_RTL)
+
+mark_as_advanced(COREIR_FOUND COREIR_INCLUDE_DIR COREIR_LIBRARIES)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.o
 *.pyc
 .cache
+# cmake
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required (VERSION 3.0)
+set(CMAKE_CXX_STANDARD 11)
+
+project (CGRAMapper
+         VERSION 1.0.0)
+
+# include custom modules
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/.cmake/")
+# some command C++ flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wfatal-errors")
+
+# default debug build
+# this will set debug flags properly
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+endif(NOT CMAKE_BUILD_TYPE)
+
+# find core_ir
+find_package(CoreIR REQUIRED)
+
+# keep the output to old bin folder, instead of cmake build
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+
+# fPIC
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# include directories
+# we only have src
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_library(cgra SHARED libs/cgralib.cpp)
+target_include_directories(cgra PRIVATE ${COREIR_INCLUDE_DIR}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+FILE(GLOB HEADER_FILES */*.h)
+# don't know why everything is implemented in header files
+add_executable(cgra-mapper ${HEADER_FILES} mapper.cpp)
+target_include_directories(cgra-mapper PRIVATE ${COREIR_INCLUDE_DIR}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(cgra-mapper ${COREIR_LIBRARIES} cgra)


### PR DESCRIPTION
This PR adds `cmake` build system. Currently you need to install CoreIR in system's root folder in order to compile the mapper. This PR introduces `FindCoreIR` to cmake to allow build system to automatically detect the CoreIR build.

Usage:
```
$ mkdir build && cd build
$ cmake .. -DCOREIR_DIR=${absolute_path_of_core_ir}$
$ make -j
```
It will produce `cgra-mapper` in the `bin` folder as before. If you have `$COREIR_DIR` set  in your `env`, the script will automatically reads it so you can skip the flag passing to `cmake`.